### PR TITLE
Fix wrong _id being returned with document during a bulk update

### DIFF
--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -709,6 +709,7 @@ class Mongo(DataLayer):
         ids = []
         operations = []
         bulk_lookup_queries = {}
+        response_documents = []
         
         try:
             for doc in doc_or_docs:
@@ -736,15 +737,19 @@ class Mongo(DataLayer):
                 # perform bulk write operations in chunks
                 if len(operations) == 1000:
                     coll.bulk_write(operations, ordered=True)
-                    ids.extend([resp['_id'] for resp in coll.find(bulk_lookup_queries, projection=["_id"])])
+                    for resp in coll.find(bulk_lookup_queries):
+                        ids.append(resp['_id'])
+                        response_documents.append(resp)
                     bulk_lookup_queries = {}
                     operations = []
             
             if len(operations) > 0:
                 coll.bulk_write(operations, ordered=True)
-                ids.extend([resp['_id'] for resp in coll.find(bulk_lookup_queries, projection=["_id"])])
+                for resp in coll.find(bulk_lookup_queries):
+                        ids.append(resp['_id'])
+                        response_documents.append(resp)
             
-            return ids
+            return ids, response_documents
         except pymongo.errors.BulkWriteError as e:
             self.app.logger.exception(e)
 

--- a/eve/io/mongo/mongo.py
+++ b/eve/io/mongo/mongo.py
@@ -706,7 +706,6 @@ class Mongo(DataLayer):
         if isinstance(doc_or_docs, dict):
             doc_or_docs = [doc_or_docs]
 
-        ids = []
         operations = []
         bulk_lookup_queries = {}
         response_documents = []
@@ -737,19 +736,15 @@ class Mongo(DataLayer):
                 # perform bulk write operations in chunks
                 if len(operations) == 1000:
                     coll.bulk_write(operations, ordered=True)
-                    for resp in coll.find(bulk_lookup_queries):
-                        ids.append(resp['_id'])
-                        response_documents.append(resp)
+                    response_documents.extend(coll.find(bulk_lookup_queries))
                     bulk_lookup_queries = {}
                     operations = []
             
             if len(operations) > 0:
                 coll.bulk_write(operations, ordered=True)
-                for resp in coll.find(bulk_lookup_queries):
-                        ids.append(resp['_id'])
-                        response_documents.append(resp)
+                response_documents.extend(coll.find(bulk_lookup_queries))
             
-            return ids, response_documents
+            return response_documents
         except pymongo.errors.BulkWriteError as e:
             self.app.logger.exception(e)
 

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -260,7 +260,7 @@ def post_internal(resource, payl=None, skip_validation=False):
         # bulk insert
         ids = []
         if unique_lookup_key:
-            ids, documents = app.data.bulk_update(resource, unique_lookup_key, documents)
+            documents = app.data.bulk_update(resource, unique_lookup_key, documents)
         else:
             ids = app.data.insert(resource, documents)
 
@@ -271,8 +271,13 @@ def post_internal(resource, payl=None, skip_validation=False):
         for document in documents:
             # either return the custom ID_FIELD or the id returned by
             # data.insert().
-            id_ = document.get(id_field, ids.pop(0))
-            document[id_field] = id_
+            # documents updated or upserted through a bulk update will always have 
+            # the "_id" field set.
+            if "_id" in document:
+                document[id_field] = document['_id']
+            else:
+                id_ = document.get(id_field, ids.pop(0))
+                document[id_field] = id_
 
             # build the full response document
             result = document

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -269,13 +269,11 @@ def post_internal(resource, payl=None, skip_validation=False):
 
         # assign document ids
         for document in documents:
-            # either return the custom ID_FIELD or the id returned by
-            # data.insert().
             # documents updated or upserted through a bulk update will always have 
             # the "_id" field set.
-            if "_id" in document:
-                document[id_field] = document['_id']
-            else:
+            if not unique_lookup_key:
+                # either return the custom ID_FIELD or the id returned by
+                # data.insert().
                 id_ = document.get(id_field, ids.pop(0))
                 document[id_field] = id_
 

--- a/eve/methods/post.py
+++ b/eve/methods/post.py
@@ -260,7 +260,7 @@ def post_internal(resource, payl=None, skip_validation=False):
         # bulk insert
         ids = []
         if unique_lookup_key:
-            ids = app.data.bulk_update(resource, unique_lookup_key, documents)
+            ids, documents = app.data.bulk_update(resource, unique_lookup_key, documents)
         else:
             ids = app.data.insert(resource, documents)
 


### PR DESCRIPTION
# Fix wrong _id being returned with document during a bulk update
Jira: https://jira.catalogicsoftware.com/browse/KUBEDR-2148

Some context from my comment on the jira:
`During the EKS cluster inventory job we get all the EKS clusters and then do a bulk insert. In the awseksclusters resource in apiserver, there is some logic in after_db_insert to check if the kubecluster resource already exists, and if not it creates it. Afterwards it does an eve_patch_internal to update the same awsekscluster resource to store the id of the newly create kubecluster resource. In this eve_patch_internal the lookup to update was just _id=item['_ id'] but for some reason it was updating the wrong awseksclusters resource.`

It turned out the issue isn't with the eve_patch_internal but with the _id itself. The value of the _id field was giving the ID of a different awseksclusters resource. This would only happen after a bulk update (bulk insert is unaffected). The issue turned out to be because after the bulk update, I was doing a find to get a list of IDs, however those list of IDs needed to match the already existing list of documents. Basically the list of IDs that needed to be returned must be in the exact order as the list of documents being inserted. To fix this I created a list of IDs and a list of documents during the bulk update and return both.